### PR TITLE
Fix button size in storage info

### DIFF
--- a/src/app/components/layout/PrivateLayout.js
+++ b/src/app/components/layout/PrivateLayout.js
@@ -15,7 +15,7 @@ const PrivateLayout = ({ children }) => {
             <AppsSidebar
                 items={[
                     <StorageSpaceStatus key="storage">
-                        <Link to="/settings/subscription" className="pm-button pm-button--primary">
+                        <Link to="/settings/subscription" className="pm-button pm-button--primary pm-button--small">
                             {c('Action').t`Upgrade`}
                         </Link>
                     </StorageSpaceStatus>


### PR DESCRIPTION
- Added helper `pm-button--small`

![image](https://user-images.githubusercontent.com/2578321/65592928-cfbb8080-df8f-11e9-934b-151147ffdc0a.png)
