### PR TITLE
Uniformize top navigation bar

### DIFF
--- a/src/app/components/layout/PrivateHeader.js
+++ b/src/app/components/layout/PrivateHeader.js
@@ -1,55 +1,21 @@
 import React from 'react';
-import { MainLogo, UserDropdown, SupportDropdown } from 'react-components';
-import { Link } from 'react-router-dom';
+import { MainLogo, TopNavbar, TopNavbarLink, SupportDropdown } from 'react-components';
 import { c } from 'ttag';
 
 const PrivateHeader = () => {
     return (
         <header className="header flex flex-nowrap reset4print">
             <MainLogo url="/inbox" external={true} />
-            <div className="searchbox-container"></div>
-            <div className="topnav-container flex-item-centered-vert flex-item-fluid">
-                <ul className="topnav-list unstyled mt0 mb0 ml1 flex flex-nowrap">
-                    <li className="mr1">
-                        <a href="/inbox" className="topnav-link inline-flex flex-nowrap nodecoration rounded">
-                            <svg
-                                viewBox="0 0 16 16"
-                                className="icon-16p flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert fill-white"
-                                role="img"
-                                focusable="false"
-                                aria-hidden="true"
-                            >
-                                <use xlinkHref="#shape-email" />
-                            </svg>
-                            <span className="navigation-title topnav-linkText">{c('Title').t`Mailbox`}</span>
-                        </a>
-                    </li>
-                    <li className="mr1">
-                        <Link
-                            to="/settings"
-                            className="topnav-link inline-flex flex-nowrap nodecoration rounded"
-                            aria-current="true"
-                        >
-                            <svg
-                                viewBox="0 0 16 16"
-                                className="icon-16p flex-item-noshrink topnav-icon mr0-5 flex-item-centered-vert fill-white"
-                                role="img"
-                                focusable="false"
-                                aria-hidden="true"
-                            >
-                                <use xlinkHref="#shape-settings-master" />
-                            </svg>
-                            <span className="navigation-title topnav-linkText">{c('Title').t`Settings`}</span>
-                        </Link>
-                    </li>
-                    <li className="mr1">
-                        <SupportDropdown className="topnav-link inline-flex flex-nowrap nodecoration rounded" />
-                    </li>
-                    <li className="mlauto mtauto mbauto relative flex-item-noshrink">
-                        <UserDropdown />
-                    </li>
-                </ul>
-            </div>
+            <TopNavbar>
+                <TopNavbarLink to="/inbox" icon="email" text={c('Title').t`Mailbox`} />
+                <TopNavbarLink
+                    to="/settings"
+                    icon="settings-master"
+                    text={c('Title').t`Settings`}
+                    aria-current="true"
+                />
+                <SupportDropdown />
+            </TopNavbar>
         </header>
     );
 };

--- a/src/app/components/layout/PrivateHeader.js
+++ b/src/app/components/layout/PrivateHeader.js
@@ -7,7 +7,7 @@ const PrivateHeader = () => {
         <header className="header flex flex-nowrap reset4print">
             <MainLogo url="/inbox" external={true} />
             <TopNavbar>
-                <TopNavbarLink to="/inbox" icon="email" text={c('Title').t`Mailbox`} />
+                <TopNavbarLink to="/inbox" external={true} icon="email" text={c('Title').t`Mailbox`} />
                 <TopNavbarLink
                     to="/settings"
                     icon="settings-master"


### PR DESCRIPTION
Needs new React components from ProtonMail/react-components#330

Use new React components in the top navigation bar. See https://github.com/ProtonMail/proton-contacts/pull/175 for the `proton-contacts` companion