### PR TITLE
Add core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     },
     "dependencies": {
         "abortcontroller-polyfill": "^1.2.1",
+        "core-js": "^3.3.6",
         "design-system": "github:ProtonMail/design-system.git#master",
         "pmcrypto": "github:ProtonMail/pmcrypto.git#semver:^6.0.0",
         "proton-pack": "github:ProtonMail/proton-pack#semver:^2.0.0",


### PR DESCRIPTION
I'm not sure if it's because I use `yarn` instead of `npm` but the project won't start if I don't install `core-js`. So it might be better to have it in dependency.