### PR TITLE
Fix - height of right nav container

### DIFF
--- a/src/app/components/layout/PrivateLayout.js
+++ b/src/app/components/layout/PrivateLayout.js
@@ -49,7 +49,7 @@ const PrivateLayout = ({ children, location }) => {
                         )}
                     />
                     <div className="main flex-item-fluid main-area" ref={mainAreaRef}>
-                        <div className="flex flex-reverse">
+                        <div className="flex flex-reverse h100">
                             <MainAreaContext.Provider value={mainAreaRef}>{children}</MainAreaContext.Provider>
                         </div>
                     </div>


### PR DESCRIPTION
Before :
![image](https://user-images.githubusercontent.com/2578321/68899095-2db74980-0731-11ea-99ca-a774e1f3c381.png)

After:
![image](https://user-images.githubusercontent.com/2578321/68899119-40ca1980-0731-11ea-96b6-ed2ed0bba6d1.png)

- added `h100` helper on container